### PR TITLE
Fix hidden directory check always looks at the topmost component

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -117,7 +117,7 @@ pub fn main() !void {
     defer dirWalker.deinit();
     while (try dirWalker.next()) |entry| {
         // NOTE: Revisit blocking all the hidden files
-        if (entry.kind == .directory and std.mem.startsWith(u8, entry.path, ".")) {
+        if (entry.kind == .directory and std.mem.startsWith(u8, entry.basename, ".")) {
             dirWalker.skip();
             continue;
         }


### PR DESCRIPTION
Before this commit, only top-level hidden directories would be skipped, so e.g. this would be found:

```
 → src/.hidden/foo.zig
FIXME: I'm hidden
```

After this commit, the basename (e.g. `.hidden`) of each entry is checked (instead of the path, e.g. `src/.hidden`), so hidden directories that aren't at the top-level of the tree are skipped as well.